### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This project is a Model Control Protocol (MCP) server for accessing Zoom API functionality without requiring direct authentication from the end user. It handles the OAuth flows and provides a set of tools for interacting with Zoom recordings and transcripts.
 
+<a href="https://glama.ai/mcp/servers/@peakmojo/mcp-server-zoom-noauth">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@peakmojo/mcp-server-zoom-noauth/badge" alt="Zoom Recordings No-Auth MCP server" />
+</a>
+
 ## Features
 
 - OAuth credential management through tool arguments (no local auth flow)


### PR DESCRIPTION
This PR adds a badge for the [Zoom Recordings No-Auth](https://glama.ai/mcp/servers/@peakmojo/mcp-server-zoom-noauth) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@peakmojo/mcp-server-zoom-noauth">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@peakmojo/mcp-server-zoom-noauth/badge" alt="Zoom Recordings No-Auth MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.